### PR TITLE
fix:health-check failure on PasS platform 

### DIFF
--- a/designer/server/createServer.ts
+++ b/designer/server/createServer.ts
@@ -14,6 +14,9 @@ import { configureYarPlugin } from "./plugins/session";
 const serverOptions = () => {
   return {
     port: process.env.PORT || 3000,
+    router: {
+      stripTrailingSlash: true
+    },
     routes: {
       validate: {
         options: {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -39,7 +39,10 @@ const serverOptions = (): ServerOptions => {
 
   const serverOptions: ServerOptions = {
     debug: { request: [`${config.isDev}`] },
-    port: config.port,
+    port: process.env.PORT || config.port,
+    router: {
+      stripTrailingSlash: true
+    },
     routes: {
       validate: {
         options: {


### PR DESCRIPTION
update: server options to handle trailing slash
update: runner to use port from env if provided

# Description
change added Hapi server option to enable stripping trailing slash , which fixes the health-check failure on PasS platform (cloud foundry) for both runner and designer and, adds option to user port from environment variable for runner if provided 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
It does not need any additional testing , current testing should be sufficient 


# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
